### PR TITLE
SB012 Delete Sales Task Hotfix To Avoid FK Constraint

### DIFF
--- a/src/main/java/org/kainos/ea/api/SalesEmpService.java
+++ b/src/main/java/org/kainos/ea/api/SalesEmpService.java
@@ -102,8 +102,9 @@ public class SalesEmpService {
                     throw new SalesEmpDoesNotExistException();
                 }
 
-                salesEmpDao.deleteSalesEmp(id);
                 projectDao.removeProjectSalesID(id);
+                salesEmpDao.deleteSalesEmp(id);
+
             } catch (SQLException e) {
                 System.err.println(e.getMessage());
 

--- a/src/main/java/org/kainos/ea/api/SalesEmpService.java
+++ b/src/main/java/org/kainos/ea/api/SalesEmpService.java
@@ -1,10 +1,12 @@
 package org.kainos.ea.api;
 
+import org.kainos.ea.cli.Project;
 import org.kainos.ea.cli.SalesEmp;
 import org.kainos.ea.cli.SalesEmpRequest;
 import org.kainos.ea.client.*;
 import org.kainos.ea.core.SalesEmpValidator;
 import org.kainos.ea.db.DatabaseConnector;
+import org.kainos.ea.db.ProjectDao;
 import org.kainos.ea.db.SalesEmpDao;
 
 import java.sql.Connection;
@@ -13,6 +15,7 @@ import java.util.List;
 
 public class SalesEmpService {
     SalesEmpDao salesEmpDao = new SalesEmpDao();
+    private ProjectDao projectDao = new ProjectDao();
 
     private static Connection conn;
     private static DatabaseConnector databaseConnector;
@@ -100,6 +103,7 @@ public class SalesEmpService {
                 }
 
                 salesEmpDao.deleteSalesEmp(id);
+                projectDao.removeProjectSalesID(id);
             } catch (SQLException e) {
                 System.err.println(e.getMessage());
 

--- a/src/main/java/org/kainos/ea/db/ProjectDao.java
+++ b/src/main/java/org/kainos/ea/db/ProjectDao.java
@@ -82,4 +82,15 @@ public class ProjectDao {
 
         st.executeUpdate();
     }
+
+    public void removeProjectSalesID(int id) throws SQLException {
+        Connection c = databaseConnector.getConnection();
+        String updateStatement = "UPDATE Project SET Sales_ID = null WHERE Sales_ID = ?";
+
+        PreparedStatement st = c.prepareStatement(updateStatement);
+
+        st.setInt(1, id);
+
+        st.executeUpdate();
+    }
 }


### PR DESCRIPTION
Nullified Sales_ID in the Project Table before removing the Sales row at Sales_ID in the Sales_Employee in order to avoid triggering the foreign key constraint when trying to delete the row.